### PR TITLE
[fix] AI 리스폰 시 공중에 체류하는 현상 #52

### DIFF
--- a/StarfistExpress/Content/PlatformFighterKit/Blueprints/Characters/BP_Fighter.uasset
+++ b/StarfistExpress/Content/PlatformFighterKit/Blueprints/Characters/BP_Fighter.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fdaf7e4e7546b8b4e194c2441620a5e4adc5971a0139c090dcaf84e0087becbc
-size 4329222
+oid sha256:440ca43c36f6d1a15130af5ef6a4b03cd7a0269c95ca4cbfa870d32a733a4a79
+size 4329742


### PR DESCRIPTION
 ## 💻 작업사항 
<!-- PR내용에 대해 상세 설명이 필요하다면 이 부분에 기재해 주세요. -->
  - 리스폰 구현 부분에서 states 값을 수정
  - 중력 값이 0으로 설정되어 내려오지 못하는 것으로 확인
  - fall이라는 states 로직에 중력값을 4로 설정해주는 부분이 있어 states값을 fall로 변경
<img width="716" alt="11" src="https://github.com/user-attachments/assets/3ad27479-ec84-4216-9f0a-9bcbdf9477be" />


 ## 💡Issue 번호
<!-- issue number을 link 시켜주세요 (ex. "- close #4242") -->
 - close #52 